### PR TITLE
Add arm64 / aarch64 installer support

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -179,6 +179,9 @@ detect_dist() {
         x86_64 | x86-64 | x64 | amd64)
             _cputype=x86_64
             ;;
+        arm64 | aarch64)
+            _cputype=aarch64
+            ;;
         *)
             err "invalid cputype: $_cputype"
             ;;


### PR DESCRIPTION
Currently the installer won't install ARM binaries and just plain out exit, but this change adds support for downloading ARM binaries.