### PR TITLE
Keystore add cmd typo

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -6,7 +6,7 @@
         {
             "default": true,
             "versions": ["v0.12"],
-            "add_certs": "ya-provider keystore add $(find $_resources_dir/certs -type f) --permissions outbound-manifest|unverified-permissions-chain",
+            "add_certs": "ya-provider keystore add $(find $_resources_dir/certs -type f) --permissions outbound-manifest unverified-permissions-chain",
             "whitelist_regex": "ya-provider whitelist add -t regex -p $(cat $_resources_dir/whitelist/regex.lst | tr '\\n' ' ')",
             "whitelist_strict": "ya-provider whitelist add -t strict -p $(cat $_resources_dir/whitelist/strict.lst | tr '\\n' ' ')"
         }

--- a/commands.json
+++ b/commands.json
@@ -6,7 +6,7 @@
         {
             "default": true,
             "versions": ["v0.12"],
-            "add_certs": "ya-provider keystore add $(find $_resources_dir/certs -type f) --permissions outbound-manifest unverified-permissions-chain",
+            "add_certs": "ya-provider keystore add $(find $_resources_dir/certs -type f) -p outbound-manifest unverified-permissions-chain -w",
             "whitelist_regex": "ya-provider whitelist add -t regex -p $(cat $_resources_dir/whitelist/regex.lst | tr '\\n' ' ')",
             "whitelist_strict": "ya-provider whitelist add -t strict -p $(cat $_resources_dir/whitelist/strict.lst | tr '\\n' ' ')"
         }


### PR DESCRIPTION
Resolves https://github.com/golemfactory/yagna/issues/2321
Recently introduced permission got added with a wrong separator.
Create PR so this typo will not migrate to golemsp.