### PR TITLE
add logic to handle downloading requestor binaries on linux arm (aarch64)

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -205,6 +205,9 @@ detect_dist() {
     case "$_ostype" in
     Linux)
         _ostype=linux
+        if [ "$_cputype" = "aarch64" ]; then
+            _ostype="${_ostype}_aarch64"
+        fi
         ;;
     Darwin)
         _ostype=osx

--- a/installer.sh
+++ b/installer.sh
@@ -193,13 +193,23 @@ detect_dist() {
         x86_64 | x86-64 | x64 | amd64)
             _cputype=x86_64
             ;;
+        aarch64)
+            if [ "$YA_INSTALLER_VARIANT" == "provider" ]; then
+                err "invalid cputype: $_cputype"
+            else
+                _cputype=aarch64
+            fi
+            ;;
         *)
             err "invalid cputype: $_cputype"
             ;;
     esac
     case "$_ostype" in
-        Linux)
+    	Linux)
             _ostype=linux
+            if [ "$_cputype" = "aarch64" ]; then
+                _ostype="${_ostype}_aarch64"
+            fi
             ;;
         Darwin)
             _ostype=osx


### PR DESCRIPTION
currently requestor installations are available via manual install but with a little bash scripting modification this can be automated via the as-requestor script. the modifications i have made should produces as-requestor (as-provider) production and development bash installation scripts via the standard gen.py to automatically work for a requestor installation on linux with an arm based cpu (aarch64) but to emit an error as expected on provider installs.

the only file modified is the template install.sh and specifically only one function is modified, detect_dist(), so that:

1. detect_dist() now tests for _cputype reported as aarch64 and fails if it is a provider install
2. detect_dust() post processes _ostype script variable in linux where cputype is aarch64 so that '_aarch64' is concatenated to 'linux' to correctly resolve to the canonical naming scheme used for linux arm variants e.g:
-  golem-requestor-linux-v0.12.2.tar.gz
-  golem-requestor-linux_aarch64-v0.12.2.tar.gz 

note, the given code makes it easy to support provider installs on linux arm when available simply by commenting or removing the logic that tests for "provider"

this pull shall close issue #45 and #24
