### PR TITLE
Enable outbound network domain whitelist rule for everyone

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -22,7 +22,8 @@
             "versions": ["v0.13.0-rc2"],
             "cmds": [
                 "ya-provider pre-install",
-                "golemsp manifest-bundle add $_resources_dir"
+                "golemsp manifest-bundle add $_resources_dir",
+                "ya-provider rule set outbound everyone --mode whitelist"
             ]
         }
     ]

--- a/commands.json
+++ b/commands.json
@@ -12,7 +12,7 @@
             ]
         },
         {
-            "versions": ["v0.12"],
+            "versions": ["v0.12", "v0.12.1", "v0.12.2"],
             "cmds": [
                 "golemsp manifest-bundle add $_resources_dir"
             ]


### PR DESCRIPTION
Enable outbound network domain whitelist rule for everyone (by default rule's mode is set to `none`).
The rule will be applied to releases v0.12.3+.
Older `ya-provider`s do not have `pre-install` and `rule` commands.