### PR TITLE
Fix mktemp on alpine

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -278,7 +278,7 @@ download_vm() {
 
 download_resources() {
     local _resources_dir _url
-    _resources_dir="$(mktemp -d /tmp/ya_installer_resources.XXXX)"
+    _resources_dir="$(mktemp -d /tmp/ya_installer_resources.XXXXXX)"
     _url="https://github.com/golemfactory/ya-installer-resources/releases/latest/download/resources.tar.gz"
     _dl_start "Downloading certificates and whitelists" ""
     (downloader "$_url" - | tar -C "$_resources_dir" -xz -f -) || err "failed to download $_url"


### PR DESCRIPTION
```
$ curl -sSf join.golem.network/as-provider | bash -

By installing & running this software you declare that you have read, understood and hereby accept the disclaimer and
privacy warning found at https://handbook.golem.network/see-also/terms

Do you accept the terms and conditions? [yes/no]: yes
golem-installer: installing to /root/.local/bin
....
...
mktemp: Invalid argument
Downloading certificates and whitelists                           tar: can't change directory to '': No such file or directory
curl: (23) Failure writing output to destination
failed to download https://github.com/golemfactory/ya-installer-resources/releases/latest/download/resources.tar.gz
```
We have similar problem to described here: https://github.com/pires/docker-elasticsearch/issues/56#issuecomment-367033995